### PR TITLE
Add support for custom paths and encrypted persistent Realms

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See the `example` directory for a complete sample app using Realm Database.
 
 ## Features 
 
-- [x] Persistent and In-memory Realm
+- [x] Persistent, In-memory, and Encrypted Realm
 - [x] deleteAllObjects
 - [x] Get allObjects by classname
 - [x] Create object 

--- a/android/src/main/java/com/it_nomads/flutter_realm/FlutterRealm.java
+++ b/android/src/main/java/com/it_nomads/flutter_realm/FlutterRealm.java
@@ -33,24 +33,21 @@ class FlutterRealm {
         RealmConfiguration.Builder builder = new RealmConfiguration.Builder().modules(Realm.getDefaultModule());
 
         byte[] encryptionKey = (byte[]) arguments.get("encryptionKey");
-        String fileDirectory = (String) arguments.get("fileDirectory");
-        String fileName = (String) arguments.get("fileName");
+        String filePath = (String) arguments.get("filePath");
         String inMemoryIdentifier = (String) arguments.get("inMemoryIdentifier");
 
         if (inMemoryIdentifier != null) {
             builder.inMemory().name(inMemoryIdentifier);
-        } else if (fileDirectory != null || fileName != null) {
-            if (fileDirectory != null) {
-                RealmConfiguration tmp = builder.build();
-                File file = new File(tmp.getRealmDirectory(), fileDirectory);
-                builder.directory(file);
+        } else {
+            if (filePath != null) {
+                File file = new File(filePath);
+                File directory = new File(file.getParent());
+                builder.directory(directory);
+                builder.name(file.getName());
             }
-            if (fileName != null) {
-                builder.name(fileName);
+            if (encryptionKey != null) {
+                builder.encryptionKey(encryptionKey);
             }
-        }
-        if (encryptionKey != null) {
-            builder.encryptionKey(encryptionKey);
         }
         RealmConfiguration config = builder.build();
 

--- a/android/src/main/java/com/it_nomads/flutter_realm/FlutterRealm.java
+++ b/android/src/main/java/com/it_nomads/flutter_realm/FlutterRealm.java
@@ -1,5 +1,6 @@
 package com.it_nomads.flutter_realm;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,11 +32,25 @@ class FlutterRealm {
 
         RealmConfiguration.Builder builder = new RealmConfiguration.Builder().modules(Realm.getDefaultModule());
 
+        byte[] encryptionKey = (byte[]) arguments.get("encryptionKey");
+        String fileDirectory = (String) arguments.get("fileDirectory");
+        String fileName = (String) arguments.get("fileName");
         String inMemoryIdentifier = (String) arguments.get("inMemoryIdentifier");
 
-        if (inMemoryIdentifier == null) {
-        } else {
+        if (inMemoryIdentifier != null) {
             builder.inMemory().name(inMemoryIdentifier);
+        } else if (fileDirectory != null || fileName != null) {
+            if (fileDirectory != null) {
+                RealmConfiguration tmp = builder.build();
+                File file = new File(tmp.getRealmDirectory(), fileDirectory);
+                builder.directory(file);
+            }
+            if (fileName != null) {
+                builder.name(fileName);
+            }
+        }
+        if (encryptionKey != null) {
+            builder.encryptionKey(encryptionKey);
         }
         RealmConfiguration config = builder.build();
 

--- a/example/README.md
+++ b/example/README.md
@@ -2,3 +2,4 @@
 
 * Run integration tests for database with `flutter driver --target=test_driver/realm_database.dart`.
 * Run integration tests for Realm Sync with `INSTANCE_LINK=<your_instance_host> flutter driver --target=test_driver/realm_sync.dart`. 
+* Run unit tests for encryption with `flutter test test/encrypted_realm_storage_test.dart`.

--- a/example/lib/app.dart
+++ b/example/lib/app.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_realm_example/helpers/encrypted_realm_storage.dart';
 
 import 'fetch_widget.dart';
 import 'helpers/local_realm_provider.dart';
+import 'helpers/encrypted_realm_provider.dart';
 import 'subscription_widget.dart';
 import 'sync/sync.dart';
 
@@ -18,6 +20,19 @@ class MyApp extends StatelessWidget {
                   builder: (realm) => FetchWidget(
                     realm: realm,
                   ),
+                ),
+              );
+              break;
+            case '/fetchencrypted':
+              return MaterialPageRoute(
+                builder: (_) => EncryptedRealmProvider(
+                  builder: (realm) => FetchWidget(
+                    realm: realm,
+                  ),
+                  storage: EncryptedRealmStorage(
+                    aes256Hex: '5870cce530afbb10cf55604bf28693921e540bd1dc75c3df8f6a9dd55c1633707b50727d9c0b0f2326469cfba08feb28fd444b5b290a39a8544ee2332eea1d4b',
+                    relativePath: '/foo/encrypted.realm'
+                  )
                 ),
               );
               break;
@@ -55,9 +70,15 @@ class Home extends StatelessWidget {
         children: <Widget>[
           ListTile(
             key: Key('Fetch'),
-            title: Text('Database Fetch'),
+            title: Text('Database Fetch - In Memory'),
             trailing: Icon(Icons.navigate_next),
             onTap: () => Navigator.of(context).pushNamed('/fetch'),
+          ),
+          ListTile(
+            key: Key('FetchEncrypted'),
+            title: Text('Database Fetch - Encrypted File'),
+            trailing: Icon(Icons.navigate_next),
+            onTap: () => Navigator.of(context).pushNamed('/fetchencrypted'),
           ),
           ListTile(
             key: Key('Subscribe'),

--- a/example/lib/helpers/encrypted_realm_provider.dart
+++ b/example/lib/helpers/encrypted_realm_provider.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_realm/flutter_realm.dart';
+import 'package:flutter_realm_example/helpers/encrypted_realm_storage.dart';
+
+class EncryptedRealmProvider extends StatefulWidget {
+  final Widget Function(Realm) builder;
+  final EncryptedRealmStorage storage;
+
+  const EncryptedRealmProvider({Key key, this.builder, this.storage}) : super(key: key);
+
+  @override
+  _EncryptedRealmProviderState createState() => _EncryptedRealmProviderState();
+}
+
+class _EncryptedRealmProviderState extends State<EncryptedRealmProvider> {
+  Future<Realm> realm;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.storage.filePath().then((String filePath) {
+      setState(() {
+        final configuration = Configuration(
+            encryptionKey: widget.storage.encryptionKey(),
+            filePath: filePath
+        );
+        realm = Realm.open(configuration);
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Realm>(
+      future: realm,
+      builder: (context, snapshot) {
+        if (snapshot.data == null) {
+          return Scaffold(
+            appBar: AppBar(),
+            body: Center(
+              child: CircularProgressIndicator(),
+            ),
+          );
+        }
+        return widget.builder(snapshot.data);
+      },
+    );
+  }
+}

--- a/example/lib/helpers/encrypted_realm_storage.dart
+++ b/example/lib/helpers/encrypted_realm_storage.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+import 'package:convert/convert.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+
+
+class EncryptedRealmStorage {
+  final String _aes256Hex;
+  final String _relativePath;
+
+  EncryptedRealmStorage({
+    @required String aes256Hex,
+    String relativePath
+  }) : this._aes256Hex = aes256Hex, this._relativePath = relativePath;
+
+  Future<String> get _localPath async {
+    final directory = await getApplicationDocumentsDirectory();
+    return directory.path;
+  }
+
+  Future<File> get _localFile async {
+    final path = await _localPath;
+    return File(path + this._relativePath);
+  }
+
+  Future<String> filePath() async {
+    final file = await _localFile;
+    await file.parent.create(recursive: true);
+    return file.path;
+  }
+
+  Uint8List encryptionKey() {
+    return hex.decode(this._aes256Hex);
+  }
+
+  static Uint8List generateKey() {
+    int byteLength = 64;
+    final values = List<int>.generate(byteLength, (i) => Random.secure().nextInt(256));
+    return Uint8List.fromList(values);
+  }
+
+  static String generateKeyHex() {
+    return hex.encode(generateKey());
+  }
+
+}

--- a/example/lib/helpers/local_realm_provider.dart
+++ b/example/lib/helpers/local_realm_provider.dart
@@ -1,3 +1,6 @@
+import 'package:convert/convert.dart';
+import 'dart:math';
+import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_realm/flutter_realm.dart';
 import 'package:uuid/uuid.dart';
@@ -8,11 +11,11 @@ class RealmProvider extends StatefulWidget {
   const RealmProvider({Key key, this.builder}) : super(key: key);
 
   @override
-  //_RealmProviderState createState() => _InMemoryRealmProviderState();
+  _RealmProviderState createState() => _InMemoryRealmProviderState();
   //_RealmProviderState createState() => _FileRealmProviderState();
   //_RealmProviderState createState() => _FileNameRealmProviderState();
   //_RealmProviderState createState() => _FileDirectoryRealmProviderState();
-  _RealmProviderState createState() => _FileDirectoryNameRealmProviderState();
+  //_RealmProviderState createState() => _FileDirectoryNameRealmProviderState();
   //_RealmProviderState createState() => _EncryptedFileRealmProviderState();
 }
 
@@ -97,8 +100,8 @@ class _FileDirectoryNameRealmProviderState extends _RealmProviderState {
   void initState() {
     super.initState();
     final configuration = Configuration(
-        fileDirectory: 'custom_dir/sub_dir/',
-        fileName: 'custom_name.realm'
+      fileDirectory: 'custom_dir/sub_dir/',
+      fileName: 'custom_name.realm'
     );
     realm = Realm.open(configuration);
   }
@@ -106,5 +109,24 @@ class _FileDirectoryNameRealmProviderState extends _RealmProviderState {
 }
 
 class _EncryptedFileRealmProviderState extends _RealmProviderState {
+
+  @override
+  void initState() {
+    super.initState();
+    final encryptionKey = _secureRandom(64);
+    final configuration = Configuration(
+      fileDirectory: 'encrypted/',
+      fileName: 'secure.realm',
+      encryptionKey: encryptionKey
+    );
+    realm = Realm.open(configuration);
+
+    print("128 character string of hexadecimal values to decrypt realm file: " + hex.encode(encryptionKey));
+  }
+
+  static Uint8List _secureRandom(int length) {
+    final values = List<int>.generate(length, (i) => Random.secure().nextInt(256));
+    return Uint8List.fromList(values);
+  }
 
 }

--- a/example/lib/helpers/local_realm_provider.dart
+++ b/example/lib/helpers/local_realm_provider.dart
@@ -1,6 +1,4 @@
 import 'package:convert/convert.dart';
-import 'dart:math';
-import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_realm/flutter_realm.dart';
 import 'package:uuid/uuid.dart';
@@ -11,12 +9,9 @@ class RealmProvider extends StatefulWidget {
   const RealmProvider({Key key, this.builder}) : super(key: key);
 
   @override
-  _RealmProviderState createState() => _InMemoryRealmProviderState();
-  //_RealmProviderState createState() => _FileRealmProviderState();
-  //_RealmProviderState createState() => _FileNameRealmProviderState();
-  //_RealmProviderState createState() => _FileDirectoryRealmProviderState();
-  //_RealmProviderState createState() => _FileDirectoryNameRealmProviderState();
   //_RealmProviderState createState() => _EncryptedFileRealmProviderState();
+  _RealmProviderState createState() => _FileRealmProviderState();
+  //_RealmProviderState createState() => _InMemoryRealmProviderState();
 }
 
 class _RealmProviderState extends State<RealmProvider> {
@@ -46,12 +41,13 @@ class _RealmProviderState extends State<RealmProvider> {
   }
 }
 
-class _InMemoryRealmProviderState extends _RealmProviderState {
+class _EncryptedFileRealmProviderState extends _RealmProviderState {
 
   @override
   void initState() {
     super.initState();
-    final configuration = Configuration(inMemoryIdentifier: Uuid().v4());
+    final encryptionKey = hex.decode('5870cce530afbb10cf55604bf28693921e540bd1dc75c3df8f6a9dd55c1633707b50727d9c0b0f2326469cfba08feb28fd444b5b290a39a8544ee2332eea1d4b');
+    final configuration = Configuration(encryptionKey: encryptionKey);
     realm = Realm.open(configuration);
   }
 
@@ -68,65 +64,13 @@ class _FileRealmProviderState extends _RealmProviderState {
 
 }
 
-class _FileNameRealmProviderState extends _RealmProviderState {
+class _InMemoryRealmProviderState extends _RealmProviderState {
 
   @override
   void initState() {
     super.initState();
-    final configuration = Configuration(
-      fileName: 'custom_name.realm'
-    );
+    final configuration = Configuration(inMemoryIdentifier: Uuid().v4());
     realm = Realm.open(configuration);
-  }
-
-}
-
-class _FileDirectoryRealmProviderState extends _RealmProviderState {
-
-  @override
-  void initState() {
-    super.initState();
-    final configuration = Configuration(
-      fileDirectory:  'custom_dir/'
-    );
-    realm = Realm.open(configuration);
-  }
-
-}
-
-class _FileDirectoryNameRealmProviderState extends _RealmProviderState {
-
-  @override
-  void initState() {
-    super.initState();
-    final configuration = Configuration(
-      fileDirectory: 'custom_dir/sub_dir/',
-      fileName: 'custom_name.realm'
-    );
-    realm = Realm.open(configuration);
-  }
-
-}
-
-class _EncryptedFileRealmProviderState extends _RealmProviderState {
-
-  @override
-  void initState() {
-    super.initState();
-    final encryptionKey = _secureRandom(64);
-    final configuration = Configuration(
-      fileDirectory: 'encrypted/',
-      fileName: 'secure.realm',
-      encryptionKey: encryptionKey
-    );
-    realm = Realm.open(configuration);
-
-    print("128 character string of hexadecimal values to decrypt realm file: " + hex.encode(encryptionKey));
-  }
-
-  static Uint8List _secureRandom(int length) {
-    final values = List<int>.generate(length, (i) => Random.secure().nextInt(256));
-    return Uint8List.fromList(values);
   }
 
 }

--- a/example/lib/helpers/local_realm_provider.dart
+++ b/example/lib/helpers/local_realm_provider.dart
@@ -8,7 +8,12 @@ class RealmProvider extends StatefulWidget {
   const RealmProvider({Key key, this.builder}) : super(key: key);
 
   @override
-  _RealmProviderState createState() => _FileRealmProviderState();
+  //_RealmProviderState createState() => _InMemoryRealmProviderState();
+  //_RealmProviderState createState() => _FileRealmProviderState();
+  //_RealmProviderState createState() => _FileNameRealmProviderState();
+  //_RealmProviderState createState() => _FileDirectoryRealmProviderState();
+  _RealmProviderState createState() => _FileDirectoryNameRealmProviderState();
+  //_RealmProviderState createState() => _EncryptedFileRealmProviderState();
 }
 
 class _RealmProviderState extends State<RealmProvider> {
@@ -54,7 +59,47 @@ class _FileRealmProviderState extends _RealmProviderState {
   @override
   void initState() {
     super.initState();
-    final configuration = Configuration(fileName: 'myrealm.realm');
+    final configuration = Configuration();
+    realm = Realm.open(configuration);
+  }
+
+}
+
+class _FileNameRealmProviderState extends _RealmProviderState {
+
+  @override
+  void initState() {
+    super.initState();
+    final configuration = Configuration(
+      fileName: 'custom_name.realm'
+    );
+    realm = Realm.open(configuration);
+  }
+
+}
+
+class _FileDirectoryRealmProviderState extends _RealmProviderState {
+
+  @override
+  void initState() {
+    super.initState();
+    final configuration = Configuration(
+      fileDirectory:  'custom_dir/'
+    );
+    realm = Realm.open(configuration);
+  }
+
+}
+
+class _FileDirectoryNameRealmProviderState extends _RealmProviderState {
+
+  @override
+  void initState() {
+    super.initState();
+    final configuration = Configuration(
+        fileDirectory: 'custom_dir/sub_dir/',
+        fileName: 'custom_name.realm'
+    );
     realm = Realm.open(configuration);
   }
 

--- a/example/lib/helpers/local_realm_provider.dart
+++ b/example/lib/helpers/local_realm_provider.dart
@@ -1,4 +1,3 @@
-import 'package:convert/convert.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_realm/flutter_realm.dart';
 import 'package:uuid/uuid.dart';
@@ -9,9 +8,7 @@ class RealmProvider extends StatefulWidget {
   const RealmProvider({Key key, this.builder}) : super(key: key);
 
   @override
-  //_RealmProviderState createState() => _EncryptedFileRealmProviderState();
-  _RealmProviderState createState() => _FileRealmProviderState();
-  //_RealmProviderState createState() => _InMemoryRealmProviderState();
+  _RealmProviderState createState() => _RealmProviderState();
 }
 
 class _RealmProviderState extends State<RealmProvider> {
@@ -20,6 +17,8 @@ class _RealmProviderState extends State<RealmProvider> {
   @override
   void initState() {
     super.initState();
+    final configuration = Configuration(inMemoryIdentifier: Uuid().v4());
+    realm = Realm.open(configuration);
   }
 
   @override
@@ -39,38 +38,4 @@ class _RealmProviderState extends State<RealmProvider> {
       },
     );
   }
-}
-
-class _EncryptedFileRealmProviderState extends _RealmProviderState {
-
-  @override
-  void initState() {
-    super.initState();
-    final encryptionKey = hex.decode('5870cce530afbb10cf55604bf28693921e540bd1dc75c3df8f6a9dd55c1633707b50727d9c0b0f2326469cfba08feb28fd444b5b290a39a8544ee2332eea1d4b');
-    final configuration = Configuration(encryptionKey: encryptionKey);
-    realm = Realm.open(configuration);
-  }
-
-}
-
-class _FileRealmProviderState extends _RealmProviderState {
-
-  @override
-  void initState() {
-    super.initState();
-    final configuration = Configuration();
-    realm = Realm.open(configuration);
-  }
-
-}
-
-class _InMemoryRealmProviderState extends _RealmProviderState {
-
-  @override
-  void initState() {
-    super.initState();
-    final configuration = Configuration(inMemoryIdentifier: Uuid().v4());
-    realm = Realm.open(configuration);
-  }
-
 }

--- a/example/lib/helpers/local_realm_provider.dart
+++ b/example/lib/helpers/local_realm_provider.dart
@@ -8,7 +8,7 @@ class RealmProvider extends StatefulWidget {
   const RealmProvider({Key key, this.builder}) : super(key: key);
 
   @override
-  _RealmProviderState createState() => _RealmProviderState();
+  _RealmProviderState createState() => _FileRealmProviderState();
 }
 
 class _RealmProviderState extends State<RealmProvider> {
@@ -17,8 +17,6 @@ class _RealmProviderState extends State<RealmProvider> {
   @override
   void initState() {
     super.initState();
-    final configuration = Configuration(inMemoryIdentifier: Uuid().v4());
-    realm = Realm.open(configuration);
   }
 
   @override
@@ -38,4 +36,30 @@ class _RealmProviderState extends State<RealmProvider> {
       },
     );
   }
+}
+
+class _InMemoryRealmProviderState extends _RealmProviderState {
+
+  @override
+  void initState() {
+    super.initState();
+    final configuration = Configuration(inMemoryIdentifier: Uuid().v4());
+    realm = Realm.open(configuration);
+  }
+
+}
+
+class _FileRealmProviderState extends _RealmProviderState {
+
+  @override
+  void initState() {
+    super.initState();
+    final configuration = Configuration(fileName: 'myrealm.realm');
+    realm = Realm.open(configuration);
+  }
+
+}
+
+class _EncryptedFileRealmProviderState extends _RealmProviderState {
+
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -8,6 +8,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.36.4"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.11"
   args:
     dependency: transitive
     description:
@@ -21,14 +28,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   charcode:
     dependency: transitive
     description:
@@ -50,13 +57,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.3+3"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.1.3"
   csslib:
     dependency: transitive
     description:
@@ -77,7 +91,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.8"
+    version: "5.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -161,13 +175,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
+  image:
+    dependency: transitive
+    description:
+      name: image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.4"
   intl:
     dependency: transitive
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.8"
+    version: "0.16.0"
   io:
     dependency: transitive
     description:
@@ -196,20 +217,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.19"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.11.3+2"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.5"
+    version: "0.12.6"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.8"
   mime:
     dependency: transitive
     description:
@@ -251,21 +279,35 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.4"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.1"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0+1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.4.0"
   platform:
     dependency: transitive
     description:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   pool:
     dependency: transitive
     description:
@@ -279,7 +321,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.12"
   pub_semver:
     dependency: transitive
     description:
@@ -293,7 +335,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.5"
   rxdart:
     dependency: transitive
     description:
@@ -375,7 +417,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   term_glyph:
     dependency: transitive
     description:
@@ -389,21 +431,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.3"
+    version: "1.9.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:
@@ -432,6 +474,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.3"
   vm_service_client:
     dependency: transitive
     description:
@@ -452,7 +501,7 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.13"
+    version: "1.1.0"
   websocket:
     dependency: transitive
     description:
@@ -460,6 +509,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.5"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.5.0"
   yaml:
     dependency: transitive
     description:
@@ -468,4 +524,5 @@ packages:
     source: hosted
     version: "2.1.16"
 sdks:
-  dart: ">=2.2.2 <3.0.0"
+  dart: ">=2.4.0 <3.0.0"
+  flutter: ">=1.10.0 <2.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  path_provider: ^1.5.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/example/test/encrypted_realm_storage_test.dart
+++ b/example/test/encrypted_realm_storage_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_realm_example/helpers/encrypted_realm_storage.dart';
+
+void main() {
+  group('Encryption', () {
+
+    test('aes256 hex encoded string should decode to 64 bytes Uint8List', () {
+      final storage = EncryptedRealmStorage(aes256Hex: '5870cce530afbb10cf55604bf28693921e540bd1dc75c3df8f6a9dd55c1633707b50727d9c0b0f2326469cfba08feb28fd444b5b290a39a8544ee2332eea1d4b');
+      expect(storage.encryptionKey(), [88, 112, 204, 229, 48, 175, 187, 16, 207, 85, 96, 75, 242, 134, 147, 146, 30, 84, 11, 209, 220, 117, 195, 223, 143, 106, 157, 213, 92, 22, 51, 112, 123, 80, 114, 125, 156, 11, 15, 35, 38, 70, 156, 251, 160, 143, 235, 40, 253, 68, 75, 91, 41, 10, 57, 168, 84, 78, 226, 51, 46, 234, 29, 75]);
+    });
+
+    test('generated aes256 hex encoded string length should be 128 characters', () {
+      final hex = EncryptedRealmStorage.generateKeyHex();
+      expect(hex, hasLength(128));
+    });
+
+    test('generated aes256 hex strings should be random', () {
+      final hexStrings = <String>[];
+      for (var i = 0; i < 10; i++) {
+        final hex = EncryptedRealmStorage.generateKeyHex();
+        expect(hexStrings, isNot(contains(hex)));
+        hexStrings.add(hex);
+      }
+    });
+
+  });
+}

--- a/example/test_driver/page_objects/home_page_object.dart
+++ b/example/test_driver/page_objects/home_page_object.dart
@@ -5,6 +5,7 @@ class HomePageObject {
   HomePageObject(this.driver);
 
   SerializableFinder get fetchTestFinder => find.byValueKey('Fetch');
+  SerializableFinder get fetchEncryptedTestFinder => find.byValueKey('FetchEncrypted');
   SerializableFinder get subscribeTestFinder => find.byValueKey('Subscribe');
   SerializableFinder get syncTestFinder => find.byValueKey('Sync');
 

--- a/example/test_driver/realm_database_test.dart
+++ b/example/test_driver/realm_database_test.dart
@@ -48,6 +48,17 @@ void main() {
       await productsPage.hasProducts(products);
     });
 
+    test('fetch encrypted', () async {
+      await driver.waitFor(homePage.fetchEncryptedTestFinder);
+      await driver.tap(homePage.fetchEncryptedTestFinder);
+
+      final products = ['1 iPhone', '2 iPad', '3 iMac', '4 Stand 999\$'];
+
+      await productsPage.createProducts(products);
+
+      await productsPage.hasProducts(products);
+    });
+
     test('subscribe', () async {
       await driver.waitFor(homePage.subscribeTestFinder);
       await driver.tap(homePage.subscribeTestFinder);

--- a/ios/Classes/FlutterRealm.m
+++ b/ios/Classes/FlutterRealm.m
@@ -66,6 +66,11 @@
         if ([arguments[@"inMemoryIdentifier"] isKindOfClass:[NSString class]]){
             config.inMemoryIdentifier = arguments[@"inMemoryIdentifier"];
         }
+
+        if ([arguments[@"fileName"] isKindOfClass:[NSString class]]){
+            // TODO: Allow filePath and fileName configuration
+            config.fileURL = [NSURL fileURLWithPath:arguments[@"fileName"]];
+        }
         
         _realmId = identifier;
         _channel = channel;

--- a/ios/Classes/FlutterRealm.m
+++ b/ios/Classes/FlutterRealm.m
@@ -81,7 +81,12 @@
             }
             config.fileURL = fileURL;
         }
-        
+
+        if ([arguments[@"encryptionKey"] isKindOfClass:[FlutterStandardTypedData class]]) {
+            FlutterStandardTypedData* uint8list = arguments[@"encryptionKey"];
+            config.encryptionKey = uint8list.data;
+        }
+
         _realmId = identifier;
         _channel = channel;
         _tokens = [NSMutableDictionary dictionary];

--- a/ios/Classes/FlutterRealm.m
+++ b/ios/Classes/FlutterRealm.m
@@ -65,26 +65,14 @@
         
         if ([arguments[@"inMemoryIdentifier"] isKindOfClass:[NSString class]]) {
             config.inMemoryIdentifier = arguments[@"inMemoryIdentifier"];
-        } else if ([arguments[@"fileDirectory"] isKindOfClass:[NSString class]] || [arguments[@"fileName"] isKindOfClass:[NSString class]]) {
-            NSURL* fileURL = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] firstObject];
-            if ([arguments[@"fileDirectory"] isKindOfClass:[NSString class]]) {
-                fileURL = [fileURL URLByAppendingPathComponent:arguments[@"fileDirectory"] isDirectory:YES];
-                [[NSFileManager defaultManager] createDirectoryAtPath:fileURL.path
-                                          withIntermediateDirectories:YES
-                                                           attributes:nil
-                                                                error:NULL];
+        } else {
+            if ([arguments[@"filePath"] isKindOfClass:[NSString class]]) {
+                config.fileURL = [NSURL fileURLWithPath:arguments[@"filePath"] isDirectory:NO];
             }
-            if ([arguments[@"fileName"] isKindOfClass:[NSString class]]) {
-                fileURL = [fileURL URLByAppendingPathComponent:arguments[@"fileName"] isDirectory:NO];
-            } else {
-                fileURL = [fileURL URLByAppendingPathComponent:@"default.realm" isDirectory:NO];
+            if ([arguments[@"encryptionKey"] isKindOfClass:[FlutterStandardTypedData class]]) {
+                FlutterStandardTypedData* uint8list = arguments[@"encryptionKey"];
+                config.encryptionKey = uint8list.data;
             }
-            config.fileURL = fileURL;
-        }
-
-        if ([arguments[@"encryptionKey"] isKindOfClass:[FlutterStandardTypedData class]]) {
-            FlutterStandardTypedData* uint8list = arguments[@"encryptionKey"];
-            config.encryptionKey = uint8list.data;
         }
 
         _realmId = identifier;

--- a/ios/Classes/FlutterRealm.m
+++ b/ios/Classes/FlutterRealm.m
@@ -63,13 +63,23 @@
     if (self != nil) {
         RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
         
-        if ([arguments[@"inMemoryIdentifier"] isKindOfClass:[NSString class]]){
+        if ([arguments[@"inMemoryIdentifier"] isKindOfClass:[NSString class]]) {
             config.inMemoryIdentifier = arguments[@"inMemoryIdentifier"];
-        }
-
-        if ([arguments[@"fileName"] isKindOfClass:[NSString class]]){
-            // TODO: Allow filePath and fileName configuration
-            config.fileURL = [NSURL fileURLWithPath:arguments[@"fileName"]];
+        } else if ([arguments[@"fileDirectory"] isKindOfClass:[NSString class]] || [arguments[@"fileName"] isKindOfClass:[NSString class]]) {
+            NSURL* fileURL = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] firstObject];
+            if ([arguments[@"fileDirectory"] isKindOfClass:[NSString class]]) {
+                fileURL = [fileURL URLByAppendingPathComponent:arguments[@"fileDirectory"] isDirectory:YES];
+                [[NSFileManager defaultManager] createDirectoryAtPath:fileURL.path
+                                          withIntermediateDirectories:YES
+                                                           attributes:nil
+                                                                error:NULL];
+            }
+            if ([arguments[@"fileName"] isKindOfClass:[NSString class]]) {
+                fileURL = [fileURL URLByAppendingPathComponent:arguments[@"fileName"] isDirectory:NO];
+            } else {
+                fileURL = [fileURL URLByAppendingPathComponent:@"default.realm" isDirectory:NO];
+            }
+            config.fileURL = fileURL;
         }
         
         _realmId = identifier;

--- a/lib/flutter_realm.dart
+++ b/lib/flutter_realm.dart
@@ -1,6 +1,7 @@
 library flutter_realm;
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';

--- a/lib/src/realm.dart
+++ b/lib/src/realm.dart
@@ -218,10 +218,20 @@ class Query {
 
 class Configuration {
   final String inMemoryIdentifier;
+  final String fileDirectory;
+  final String fileName;
 
-  const Configuration({this.inMemoryIdentifier});
+  const Configuration({
+    this.inMemoryIdentifier,
+    this.fileDirectory,
+    this.fileName
+  });
 
-  Map<String, String> toMap() => {'inMemoryIdentifier': inMemoryIdentifier};
+  Map<String, String> toMap() => {
+    'inMemoryIdentifier': inMemoryIdentifier,
+    'fileDirectory': fileDirectory,
+    'fileName': fileName
+  };
 
   static const Configuration defaultConfiguration = const Configuration();
 }

--- a/lib/src/realm.dart
+++ b/lib/src/realm.dart
@@ -218,21 +218,18 @@ class Query {
 
 class Configuration {
   final Uint8List encryptionKey;
-  final String fileDirectory;
-  final String fileName;
+  final String filePath;
   final String inMemoryIdentifier;
 
   const Configuration({
     this.encryptionKey,
-    this.fileDirectory,
-    this.fileName,
+    this.filePath,
     this.inMemoryIdentifier
   });
 
   Map<String, dynamic> toMap() => {
     'encryptionKey': encryptionKey,
-    'fileDirectory': fileDirectory,
-    'fileName': fileName,
+    'filePath': filePath,
     'inMemoryIdentifier': inMemoryIdentifier
   };
 

--- a/lib/src/realm.dart
+++ b/lib/src/realm.dart
@@ -217,20 +217,23 @@ class Query {
 }
 
 class Configuration {
-  final String inMemoryIdentifier;
+  final Uint8List encryptionKey;
   final String fileDirectory;
   final String fileName;
+  final String inMemoryIdentifier;
 
   const Configuration({
-    this.inMemoryIdentifier,
+    this.encryptionKey,
     this.fileDirectory,
-    this.fileName
+    this.fileName,
+    this.inMemoryIdentifier
   });
 
-  Map<String, String> toMap() => {
-    'inMemoryIdentifier': inMemoryIdentifier,
+  Map<String, dynamic> toMap() => {
+    'encryptionKey': encryptionKey,
     'fileDirectory': fileDirectory,
-    'fileName': fileName
+    'fileName': fileName,
+    'inMemoryIdentifier': inMemoryIdentifier
   };
 
   static const Configuration defaultConfiguration = const Configuration();


### PR DESCRIPTION
PR for issue/proposal #3 

`local_realm_provider.dart` contains examples for various configuration options:

- In-memory Realm
- Default persistent Realm
- Custom file name in default directory
- Subdirectory under default directory
- Custom file name and subdirectory
- Encrypted Realm
